### PR TITLE
chore(gradle): disable node for hex-arch-adapters-common

### DIFF
--- a/hex-arch-adapters-common/build.gradle.kts
+++ b/hex-arch-adapters-common/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "dev.eventk"
 
 kotlin {
-    setupPlatforms(ios = false)
+    setupPlatforms(ios = false, node = false)
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
The build is currently getting stuck with the common code, and we don't really need the node target in the hex-arch-adapters-common module, so disabling it.